### PR TITLE
feat: write post-process-data.json to postprocess/ directory

### DIFF
--- a/timerlat-post-process
+++ b/timerlat-post-process
@@ -89,7 +89,7 @@ def main():
         iter_sample['periods'].append(period)
 
     print(f"iter_sample: {iter_sample}")
-    with open('post-process-data.json', 'wt', encoding="ascii") as file:
+    with open('postprocess/post-process-data.json', 'wt', encoding="ascii") as file:
         file.write(json.dumps(iter_sample))
 
     return(0)


### PR DESCRIPTION
## Summary
- Write post-process-data.json to the postprocess/ subdirectory instead of the sample root directory
- Part of the Phase 2 migration for PERFNFV-316 (dedicated postprocess/ directory for all post-processing artifacts)

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Depends on
- toolbox PR #117 (merged) — CDMMetrics output_dir
- rickshaw PR #826 (merged) — orchestration creates/cleans postprocess/

🤖 Generated with [Claude Code](https://claude.com/claude-code)