### PR TITLE
fix: undefined cpus_list, unused --thread, unquoted test, and other bugs

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -8,7 +8,7 @@
           "dma-latency",
 	  "deepest-idle-state"
       ],
-      "vals": "[0-9]*$"
+      "vals": "^[0-9]*$"
     },
   
     "integer_gt_zero": {

--- a/timerlat-client
+++ b/timerlat-client
@@ -175,7 +175,7 @@ HK_CPUS=${CMD_OUTPUT}
 echo "HK_CPUS: ${HK_CPUS}"
 
 if [ "$no_load_balance" == "1" ]; then
-     disable_balance $cpus_list
+     disable_balance $WORKLOAD_CPUS
 fi
 
 echo
@@ -212,7 +212,7 @@ fi
 
 
 if [ "$no_load_balance" == "1" ]; then
-     enable_balance $cpus_list
+     enable_balance $WORKLOAD_CPUS
 fi
 
 if [ $rc -gt 0 ]; then

--- a/timerlat-client
+++ b/timerlat-client
@@ -137,7 +137,7 @@ WORKLOAD_CPUS=${CMD_OUTPUT}
 echo "WORKLOAD_CPUS: ${WORKLOAD_CPUS}"
 
 # Override HK_CPUS w/ house-keeping param (if defined)
-if [ -n $house_keeping ]; then
+if [ -n "${house_keeping}" ]; then
     echo "'house-keeping' param is defined: ${house_keeping}"
     # Cpu range to comma separated list: e.g. 2-3 ==> 2,3
     cmd="${TOOLBOX_HOME}/bin/cpumask.py --cpus ${house_keeping}"

--- a/timerlat-client
+++ b/timerlat-client
@@ -198,7 +198,7 @@ cmd="taskset -c ${HK_CPUS},${WORKLOAD_CPUS}
  --quiet --duration ${duration}s
  --house-keeping ${HK_CPUS} --cpus ${WORKLOAD_CPUS}
  --period ${period}
- ${priority} ${warm_up} ${dma_latency} ${deepest_idle_state}"
+ ${priority} ${warm_up} ${thread} ${dma_latency} ${deepest_idle_state}"
 echo "About to run: $cmd"
 date +%s.%N >begin.txt
 $cmd >timerlat-bin-stderrout.txt 2>&1

--- a/timerlat-post-process
+++ b/timerlat-post-process
@@ -6,7 +6,6 @@ import sys
 import os
 import math
 import json
-import yaml
 import glob
 from datetime import datetime
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Fix `disable_balance`/`enable_balance` called with undefined `$cpus_list` — use `$WORKLOAD_CPUS`
- Pass parsed `--thread` option to the `rtla timerlat` command (was silently ignored)
- Quote `$house_keeping` in `[ -n ]` test so auto-detect fallback is reachable
- Add missing `^` anchor to `integer_ge_zero` regex in multiplex.json
- Remove unused `import yaml` from post-process

Closes #11

## Test plan
- [ ] CI passes
- [ ] Verify timerlat runs with `--no-load-balance 1`
- [ ] Verify `--thread` parameter takes effect

🤖 Generated with [Claude Code](https://claude.ai/claude-code)